### PR TITLE
some bug fix and optimization

### DIFF
--- a/warp.py
+++ b/warp.py
@@ -142,9 +142,7 @@ class WorkerThread(Thread):
                 for delay, c in feed_phost(phost):
                     sleep(delay/10.0)
                     req_sc.send(c)
-                req_sc.send('\r\n')
-
-                req_sc.send('\r\n'.join(sreq))
+                req_sc.sendall('\r\n' + '\r\n'.join(sreq))
                 req_sc.send('\r\n\r\n')
 
             except:


### PR DESCRIPTION
fix:
1. location of HTTP Connection header after '\r\n\r\n' -> before '\r\n\r\n'
2. duplicated HTTP Connection header when a client also sends it -> do not append it

prevent possible problems:
1. Some buggy clients may send more data than it mentions on HTTP Content-Length header. Prevent infinite loops for this case.
2. socket.send(data) does not ensure send whole data, so I changed send() to sendall() for sending long data (HTTP content body from the client)

optimization:
remove possible unnecessary packet division (reduce the times of calling send())

ps. I am not sure the intend of the last req_sc.send('\r\n\r\n'). Maybe unnecessary?
