### PR TITLE
Preparation for PyPI registration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,14 +11,33 @@ Dependency
 
 * python >= 3.4.0
 
+How to install
+--------------
+
+You can install **warp** using ``pip``:
+
+.. code-block:: console
+
+   $ pip install warp
+
+Or if you're interested in bleeding edge of the master branch give it a try:
+
+.. code-block:: console
+
+   $ git clone git://github.com.devunt/warp.git
+   $ cd warp/
+   $ pip install -e .
+
+
 How to use
 ----------
 
-1. run with python interpreter
+1. run ``warp`` command (or you might need to run ``warp.py`` instead
+   if setuptools isn't installed in your system)
 
    .. code-block:: console
 
-      $ python3 warp.py
+      $ warp
 
 2. set browser's proxy setting to 
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+from __future__ import with_statement
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+
+def readme():
+    with open('README.rst') as f:
+        return f.read()
+
+
+setup(
+    name='warp',
+    version='0.1.0',
+    description='Simple http transparent proxy made in Python 3.4',
+    long_description=readme(),
+    url='https://github.com/devunt/warp',
+    author='JuneHyeon Bae',
+    author_email='devunt' '@' 'gmail.com',
+    license='MIT License',
+    py_modules=['warp'],
+    entry_points='''
+        [console_scripts]
+        warp = warp:main
+    ''',  # for setuptools
+    scripts=['warp.py'],  # for distutils without setuptools
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'Environment :: Web Environment',
+        'Intended Audience :: End Users/Desktop',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: POSIX',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Topic :: Internet :: Proxy Servers',
+        'Topic :: Internet :: WWW/HTTP',
+    ]
+)


### PR DESCRIPTION
- Since PyPI doesn’t support Markdown but reStructuredText instead, I converted the readme file from Markdown to RST.
- For PyPI release it has to be versioned so I also decided an arbitrary version: 0.1.0.  Of course it can be changed in setup.py script.
- For script installaton, there are a standard but less portable way and a de facto standard but more portable way:
  - [`scripts`](https://docs.python.org/3/distutils/setupscript.html#installing-scripts) is provided by `distutils` which is a part of Python standard library.  It is everywhere Python is installed, but doesn’t work well with Windows.  `warp.py` is installed in Python `bin`.
  - [`console_scripts`](https://pythonhosted.org/setuptools/setuptools.html#automatic-script-creation) is provided by `setuptools` which is a de facto standard package manager.  It is nearly everywhere Python is installed and everywhere `pip` is installed.  It works way better than standard `scripts` with Windows.  `warp` is installed in Python `bin` if `setuptools` is available, or you have to use `warp.py` command instead.
